### PR TITLE
switch from maintainer to label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM       scratch
-MAINTAINER Kelsey Hightower <kelsey.hightower@gmail.com>
+LABEL maintainer="Kelsey Hightower <kelsey.hightower@gmail.com>"
 ADD        contributors contributors
 ENV        PORT 80
 EXPOSE     80


### PR DESCRIPTION
hey there,

since maintainer is deprecated in favour of label, i suggest either you switch to the label command or remove the entire line.

source:
https://docs.docker.com/engine/reference/builder/#usage

greetings,

Benjamin